### PR TITLE
Increase Java compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("de.peilicke.sascha:log4k:1.1.0")
+    implementation("de.peilicke.sascha:log4k:1.1.1")
 }
 ```
 

--- a/log4k/build.gradle.kts
+++ b/log4k/build.gradle.kts
@@ -46,7 +46,7 @@ android {
 }
 
 group = "de.peilicke.sascha"
-version = "1.1.0"
+version = "1.1.1"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")

--- a/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
+++ b/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
@@ -1,49 +1,79 @@
 package saschpe.log4k
 
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
 import kotlin.native.concurrent.ThreadLocal
 
 @ThreadLocal
 object Log {
     enum class Level { Verbose, Debug, Info, Warning, Error, Assert }
 
+    @JvmField
     val loggers = mutableListOf<Logger>()
 
+    @JvmOverloads
+    @JvmStatic
     fun verbose(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Verbose, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun verbose(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Verbose, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun info(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Info, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun info(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Info, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun debug(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Debug, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun debug(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Debug, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun warn(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Warning, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun warn(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Warning, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun error(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Error, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun error(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Error, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun assert(message: String, throwable: Throwable? = null, tag: String = "") =
         log(Level.Assert, tag, throwable, message)
 
+    @JvmOverloads
+    @JvmStatic
     fun assert(throwable: Throwable? = null, tag: String = "", message: () -> String) =
         log(Level.Assert, tag, throwable, message())
 
+    @JvmOverloads
+    @JvmStatic
     fun log(priority: Level, tag: String = "", throwable: Throwable? = null, message: String? = null) =
         loggers.forEach { it.log(priority, tag, message, throwable) }
 }


### PR DESCRIPTION
By adding `JvmOverloads` and `@JvmStatic` annotations to generate static
methods on the 'Log' object. This makes it easier to call any log
function though JNI.

Add `@JvmField` to `Log.loggers` to keep the API simple to use in Java.