### PR TITLE
Android: Update to API 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("de.peilicke.sascha:log4k:1.1.1")
+    implementation("de.peilicke.sascha:log4k:1.1.2")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.7.0"
-    id("com.android.library") version "7.0.4" apply false
+    id("com.android.library") version "7.2.1" apply false
     id("com.diffplug.spotless") version "6.7.2"
     id("com.github.ben-manes.versions") version "0.42.0"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,5 +28,8 @@ object Secrets {
             }
         }
     }
-    named("assemble") { dependsOn(ensureSecretsExist) }
+
+    compileKotlin {
+        dependsOn(ensureSecretsExist)
+    }
 }

--- a/log4k/build.gradle.kts
+++ b/log4k/build.gradle.kts
@@ -24,7 +24,12 @@ kotlin {
     sourceSets["iosSimulatorArm64Main"].dependsOn(sourceSets["iosMain"])
     sourceSets["iosSimulatorArm64Test"].dependsOn(sourceSets["iosTest"])
 
-    sourceSets.remove(sourceSets["androidAndroidTestRelease"]) // https://issuetracker.google.com/issues/152187160
+    sourceSets { // https://issuetracker.google.com/issues/152187160
+        remove(sourceSets["androidAndroidTestRelease"])
+        remove(sourceSets["androidTestFixtures"])
+        remove(sourceSets["androidTestFixturesDebug"])
+        remove(sourceSets["androidTestFixturesRelease"])
+    }
 
     targets.withType(org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests::class.java) {
         testRuns["test"].deviceId = "iPhone 13"
@@ -32,12 +37,12 @@ kotlin {
 }
 
 android {
-    buildToolsVersion = "32.0.0"
-    compileSdk = 31
+    buildToolsVersion = "33.0.0"
+    compileSdk = 32
 
     defaultConfig {
         minSdk = 17
-        targetSdk = 31
+        targetSdk = 32
     }
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")

--- a/log4k/build.gradle.kts
+++ b/log4k/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 }
 
 group = "de.peilicke.sascha"
-version = "1.1.1"
+version = "1.1.2"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")


### PR DESCRIPTION
And use Android Gradle Plugin 7.2.1 as well as build-tools 33.0.0.
See upstream release notes:

 - https://developer.android.com/studio/releases/platforms#12
 - https://developer.android.com/studio/releases/gradle-plugin#7-2-0
 - https://developer.android.com/studio/releases/build-tools