### PR TITLE
Use ConsoleLogger by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.0] - 2022-07-11
 - Use *ConsoleLogger* by default
 
 ## [1.1.3] - 2022-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Use *ConsoleLogger* by default
 
 ## [1.1.3] - 2022-07-07
 - Add method `Log.isDebugEnabled` identical to SLF4J's `LOG.isDebugEnabled()`.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ Logging messages is straightforward, the **Log** object provides the usual
 functions you'd expect:
 
 ```kotlin
-// Configure logger types
-Log.loggers += ConsoleLogger()
-
 // Log to your heart's content
 Log.verbose("FYI")
 Log.debug("Debugging ${foo.bar}")
@@ -95,9 +92,9 @@ console logger in your Application class:
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        Log.loggers += ConsoleLogger().apply {
+        Log.loggers.forEach {
             if (!BuildConfig.DEBUG) {
-                minimumLogLevel = Log.Level.Info
+                it.minimumLogLevel = Log.Level.Info
             }
         }
     }
@@ -114,6 +111,7 @@ messages to Crashlytics in production builds, you could do the following:
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        Log.loggers.clear() // Remove default loggers
         Log.loggers += when {
             BuildConfig.DEBUG -> ConsoleLogger()
             else -> CrashlyticsLogger()

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("de.peilicke.sascha:log4k:1.1.3")
+    implementation("de.peilicke.sascha:log4k:1.2.0")
 }
 ```
 

--- a/log4k/build.gradle.kts
+++ b/log4k/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 }
 
 group = "de.peilicke.sascha"
-version = "1.1.3"
+version = "1.2.0"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")

--- a/log4k/src/commonMain/kotlin/saschpe/log4k/ConsoleLogger.kt
+++ b/log4k/src/commonMain/kotlin/saschpe/log4k/ConsoleLogger.kt
@@ -1,3 +1,3 @@
 package saschpe.log4k
 
-expect class ConsoleLogger : Logger
+expect class ConsoleLogger() : Logger

--- a/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
+++ b/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
@@ -10,7 +10,7 @@ object Log {
     enum class Level { Verbose, Debug, Info, Warning, Error, Assert }
 
     @JvmField
-    val loggers = mutableListOf<Logger>()
+    val loggers = mutableListOf<Logger>(ConsoleLogger())
 
     /**
      * Returns true if any [Logger.minimumLogLevel] is [Log.Level.Verbose] or [Log.Level.Debug]

--- a/log4k/src/commonTest/kotlin/saschpe/log4k/LogTest.kt
+++ b/log4k/src/commonTest/kotlin/saschpe/log4k/LogTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.*
 class LogTest {
     @BeforeTest // Arrange
     fun before() {
+        Log.loggers.clear()
         Log.loggers += TestLogger()
     }
 


### PR DESCRIPTION
Simplifies setup in 90% of cases and still allows to customize everything.