### PR TITLE
Add SLF4J integration as a new library

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,11 +6,21 @@
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <Markdown>
+      <option name="MAX_LINES_AROUND_HEADER" value="0" />
+    </Markdown>
     <XML>
       <option name="XML_KEEP_LINE_BREAKS" value="false" />
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </XML>
+    <codeStyleSettings language="Markdown">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="XML">
       <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2022-07-11
+
 ### Added
 
 - New library `log4k-slf4j`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New library `log4k-slf4j`:
+  - `SLF4JLogger`: Forwards log statements to [SLF4J](https://www.slf4j.org), which in turn allows to
+    use [Logback])(https://logback.qos.ch) as a backend.
+
 ## [1.2.0] - 2022-07-11
-- Use *ConsoleLogger* by default
+
+### Changed
+
+- Use `ConsoleLogger` by default
 
 ## [1.1.3] - 2022-07-07
+
+### Added
+
 - Add method `Log.isDebugEnabled` identical to SLF4J's `LOG.isDebugEnabled()`.
 - Dependency update:
   - [Kotlin 1.7.10](https://github.com/JetBrains/kotlin/releases/tag/v1.7.10)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("de.peilicke.sascha:log4k:1.2.0")
+    implementation("de.peilicke.sascha:log4k:1.2.1")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Log4K
-
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 ![Maven Central](https://img.shields.io/maven-central/v/de.peilicke.sascha/log4k)
 [![Build Status](https://github.com/saschpe/log4k/workflows/Main%20CI/badge.svg)](https://github.com/saschpe/log4k/actions)
@@ -9,11 +8,12 @@
 ![badge-jvm](http://img.shields.io/badge/platform-jvm-orange.svg?style=flat)
 ![Kotlin Version](https://img.shields.io/badge/kotlin-v1.3.60-F88909?style=flat&logo=kotlin)
 
-Lightweight logging library for Kotlin/Multiplatform. Supports Android, iOS,
-JavaScript and plain JVM environments.
+Lightweight logging library for Kotlin/Multiplatform. Supports Android, iOS, JavaScript and plain JVM environments.
+
+- **log4k**: Base library, provides infrastructure and console logging
+- **log4k-slf4j**: Integration with [SLF4J](https://www.slf4j.org)
 
 ## Download
-
 Artifacts are published to [Maven Central][maven-central]:
 
 ```kotlin
@@ -27,9 +27,7 @@ dependencies {
 ```
 
 ## Usage
-
-Logging messages is straightforward, the **Log** object provides the usual
-functions you'd expect:
+Logging messages is straightforward, the **Log** object provides the usual functions you'd expect:
 
 ```kotlin
 // Log to your heart's content
@@ -46,19 +44,17 @@ or, if you prefer:
 ```kotlin
 Log.verbose { "FYI" }
 Log.debug { "Debugging ${foo.bar}" }
-Log.info(tag = "SomeClass") {"Nice to know" }
-Log.warn {"Warning about $stuff ..." }
+Log.info(tag = "SomeClass") { "Nice to know" }
+Log.warn { "Warning about $stuff ..." }
 Log.error { "Oops!" }
 Log.assert(throwable = Exception("Ouch!")) { "Something went wrong!" }
 ```
 
-The log output includes the function name and line and pretty-prints exceptions
-on all supported platforms:
+The log output includes the function name and line and pretty-prints exceptions on all supported platforms:
 
     I/Application.onCreate: Log4K rocks!
 
 ### Logging objects
-
 In case you want to log `Any` Kotlin class instance or object:
 
 ```kotlin
@@ -69,7 +65,6 @@ map.logged()
 The above example logs `{Hello=World}` with the tag `SingletonMap` with the log level `Debug`.
 
 ### Logging expensive results
-
 Sometimes, the log output involves a heavy computation that is not always necessary. For example, if the global log
 level is set to `Info` or above, the following text would not appear in any log output:
 
@@ -84,9 +79,7 @@ Log.debug { "Some ${veryHeavyStuff()}" }
 ```
 
 ## Configuration (Android example)
-
-To only output messages with log-level *info* and above, you can configure the
-console logger in your Application class:
+To only output messages with log-level *info* and above, you can configure the console logger in your Application class:
 
 ```kotlin
 class MyApplication : Application() {
@@ -102,10 +95,8 @@ class MyApplication : Application() {
 ```
 
 ## Custom logger (Android Crashlytics example)
-
-The library provides a cross-platform `ConsoleLogger` by default. Custom
-loggers can easily be added. For instance, to send only `ERROR` and `ASSERT`
-messages to Crashlytics in production builds, you could do the following:
+The library provides a cross-platform `ConsoleLogger` by default. Custom loggers can easily be added. For instance, to
+send only `ERROR` and `ASSERT` messages to Crashlytics in production builds, you could do the following:
 
 ```kotlin
 class MyApplication : Application() {

--- a/log4k-slf4j/build.gradle.kts
+++ b/log4k-slf4j/build.gradle.kts
@@ -1,0 +1,119 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    `maven-publish`
+    signing
+}
+
+kotlin {
+    android { publishAllLibraryVariants() }
+    ios { binaries.framework("Log4K-SLF4J") }
+    iosSimulatorArm64 { binaries.framework("Log4K-SLF4J") }
+    js {
+        nodejs()
+        compilations.all {
+            kotlinOptions.sourceMap = true
+            kotlinOptions.moduleKind = "umd"
+        }
+    }
+    jvm { testRuns["test"].executionTask.configure { useJUnitPlatform() } }
+
+    sourceSets["androidMain"].dependencies {
+        implementation("org.slf4j:slf4j-api:1.7.36")
+    }
+    sourceSets["commonMain"].dependencies {
+        implementation(project(":log4k"))
+    }
+    sourceSets["commonTest"].dependencies {
+        implementation(kotlin("test"))
+    }
+    sourceSets["iosSimulatorArm64Main"].dependsOn(sourceSets["iosMain"])
+    sourceSets["iosSimulatorArm64Test"].dependsOn(sourceSets["iosTest"])
+    sourceSets["jvmMain"].dependencies {
+        implementation("org.slf4j:slf4j-api:1.7.36")
+    }
+
+    sourceSets { // https://issuetracker.google.com/issues/152187160
+        remove(sourceSets["androidAndroidTestRelease"])
+        remove(sourceSets["androidTestFixtures"])
+        remove(sourceSets["androidTestFixturesDebug"])
+        remove(sourceSets["androidTestFixturesRelease"])
+    }
+
+    targets.withType(org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests::class.java) {
+        testRuns["test"].deviceId = "iPhone 13"
+    }
+}
+
+android {
+    buildToolsVersion = "33.0.0"
+    compileSdk = 32
+
+    defaultConfig {
+        minSdk = 17
+        targetSdk = 32
+    }
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+
+    testCoverage.jacocoVersion = "0.8.8"
+}
+
+group = "de.peilicke.sascha"
+version = "1.2.0"
+
+val javadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+}
+
+publishing {
+    publications.withType<MavenPublication> {
+        artifact(javadocJar.get())
+
+        pom {
+            name.set("Log4K-SLF4J")
+            description.set("Lightweight logging library for Kotlin/Multiplatform - SLF4J integration. Supports Android, iOS, JavaScript and plain JVM environments.")
+            url.set("https://github.com/saschpe/log4k")
+
+            licenses {
+                license {
+                    name.set("MIT")
+                    url.set("https://opensource.org/licenses/MIT")
+                }
+            }
+            developers {
+                developer {
+                    id.set("saschpe")
+                    name.set("Sascha Peilicke")
+                    email.set("sascha@peilicke.de")
+                }
+            }
+            scm {
+                connection.set("scm:git:git://github.com/saschpe/log4k.git")
+                developerConnection.set("scm:git:ssh://github.com/saschpe/log4k.git")
+                url.set("https://github.com/saschpe/log4k")
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "sonatype"
+            credentials {
+                username = Secrets.Sonatype.user
+                password = Secrets.Sonatype.apiKey
+            }
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+        }
+    }
+}
+
+signing {
+    val sonatypeGpgKey = System.getenv("SONATYPE_GPG_KEY")
+    val sonatypeGpgKeyPassword = System.getenv("SONATYPE_GPG_KEY_PASSWORD")
+    when {
+        sonatypeGpgKey == null || sonatypeGpgKeyPassword == null -> useGpgCmd()
+        else -> useInMemoryPgpKeys(sonatypeGpgKey, sonatypeGpgKeyPassword)
+    }
+    sign(publishing.publications)
+}

--- a/log4k-slf4j/build.gradle.kts
+++ b/log4k-slf4j/build.gradle.kts
@@ -60,7 +60,7 @@ android {
 }
 
 group = "de.peilicke.sascha"
-version = "1.2.0"
+version = "1.2.1"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")

--- a/log4k-slf4j/src/androidMain/AndroidManifest.xml
+++ b/log4k-slf4j/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="saschpe.log4k.slf4j" />

--- a/log4k-slf4j/src/androidMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
+++ b/log4k-slf4j/src/androidMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
@@ -1,0 +1,25 @@
+package saschpe.log4k.slf4j
+
+import org.slf4j.LoggerFactory
+import saschpe.log4k.Log
+import saschpe.log4k.Logger
+
+/**
+ * Logger that forwards all log statements to SLF4J API.
+ *
+ * SLF4J in turn allows to use Logback or other implementations. This way, you can use the expressive `logback.xml`
+ * configuration and appender.
+ */
+actual class SLF4JLogger : Logger() {
+    override fun print(level: Log.Level, tag: String, message: String?, throwable: Throwable?) =
+        LoggerFactory.getLogger(tag).run {
+            when (level) {
+                Log.Level.Verbose -> trace(message, throwable)
+                Log.Level.Debug -> debug(message, throwable)
+                Log.Level.Info -> info(message, throwable)
+                Log.Level.Warning -> warn(message, throwable)
+                Log.Level.Error -> error(message, throwable)
+                Log.Level.Assert -> error(message, throwable)
+            }
+        }
+}

--- a/log4k-slf4j/src/commonMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
+++ b/log4k-slf4j/src/commonMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
@@ -1,0 +1,17 @@
+package saschpe.log4k.slf4j
+
+import saschpe.log4k.Logger
+
+/**
+ * Logger that forwards all log statements to SLF4J API on JVM and Android platforms.
+ *
+ * Suitable to replace [saschpe.log4k.ConsoleLogger]:
+ *
+ * ```kotlin
+ * Log.loggers.clear()
+ * Log.loggers += SLF4JLogger()
+ * ```
+ *
+ * On JVM or Android, SLF4J is used for logging. On JS or Apple platforms, console logging is used internally.
+ */
+expect class SLF4JLogger : Logger

--- a/log4k-slf4j/src/iosMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
+++ b/log4k-slf4j/src/iosMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
@@ -1,0 +1,12 @@
+package saschpe.log4k.slf4j
+
+import saschpe.log4k.ConsoleLogger
+import saschpe.log4k.Log
+import saschpe.log4k.Logger
+
+actual class SLF4JLogger : Logger() {
+    private val logger = ConsoleLogger()
+
+    override fun print(level: Log.Level, tag: String, message: String?, throwable: Throwable?) =
+        logger.log(level, tag, message, throwable)
+}

--- a/log4k-slf4j/src/jsMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
+++ b/log4k-slf4j/src/jsMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
@@ -1,0 +1,12 @@
+package saschpe.log4k.slf4j
+
+import saschpe.log4k.ConsoleLogger
+import saschpe.log4k.Log
+import saschpe.log4k.Logger
+
+actual class SLF4JLogger : Logger() {
+    private val logger = ConsoleLogger()
+
+    override fun print(level: Log.Level, tag: String, message: String?, throwable: Throwable?) =
+        logger.log(level, tag, message, throwable)
+}

--- a/log4k-slf4j/src/jvmMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
+++ b/log4k-slf4j/src/jvmMain/kotlin/saschpe/log4k/slf4j/SLF4JLogger.kt
@@ -1,0 +1,19 @@
+package saschpe.log4k.slf4j
+
+import org.slf4j.LoggerFactory
+import saschpe.log4k.Log
+import saschpe.log4k.Logger
+
+actual class SLF4JLogger : Logger() {
+    override fun print(level: Log.Level, tag: String, message: String?, throwable: Throwable?) =
+        LoggerFactory.getLogger(tag).run {
+            when (level) {
+                Log.Level.Verbose -> trace(message, throwable)
+                Log.Level.Debug -> debug(message, throwable)
+                Log.Level.Info -> info(message, throwable)
+                Log.Level.Warning -> warn(message, throwable)
+                Log.Level.Error -> error(message, throwable)
+                Log.Level.Assert -> error(message, throwable)
+            }
+        }
+}

--- a/log4k/build.gradle.kts
+++ b/log4k/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 }
 
 group = "de.peilicke.sascha"
-version = "1.2.0"
+version = "1.2.1"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")

--- a/scripts/release
+++ b/scripts/release
@@ -13,6 +13,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Constants
 FILES=(
   log4k/build.gradle.kts
+  log4k-slf4j/build.gradle.kts
 )
 
 # Functions

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 rootProject.name = "Log4K"
 
 include(":log4k")
+include(":log4k-slf4j")


### PR DESCRIPTION
Forwards log requests to SLF4J, which in turn allows to use Logback as a
backend. This provides rich appenders and output configuration via
`logback.xml` files. It can replace the default `ConsoleLogger` on
JVM and Android platforms. To keep things simple, the JavaScript and
Apple platform implementation log to the console.