### PR TITLE
Add default empty message parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Allow empty log messages if you only want to create a log entry about a function being called.
 - Dependency update:
   - [Kotlin 1.9.10](https://kotlinlang.org/docs/whatsnew19.html)
 

--- a/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
+++ b/log4k/src/commonMain/kotlin/saschpe/log4k/Log.kt
@@ -22,7 +22,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun verbose(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun verbose(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Verbose, tag, throwable, message)
 
     @JvmOverloads
@@ -32,7 +32,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun info(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun info(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Info, tag, throwable, message)
 
     @JvmOverloads
@@ -42,7 +42,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun debug(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun debug(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Debug, tag, throwable, message)
 
     @JvmOverloads
@@ -52,7 +52,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun warn(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun warn(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Warning, tag, throwable, message)
 
     @JvmOverloads
@@ -62,7 +62,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun error(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun error(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Error, tag, throwable, message)
 
     @JvmOverloads
@@ -72,7 +72,7 @@ object Log {
 
     @JvmOverloads
     @JvmStatic
-    fun assert(message: String, throwable: Throwable? = null, tag: String = "") =
+    fun assert(message: String = "", throwable: Throwable? = null, tag: String = "") =
         log(Level.Assert, tag, throwable, message)
 
     @JvmOverloads

--- a/log4k/src/commonTest/kotlin/saschpe/log4k/LogTest.kt
+++ b/log4k/src/commonTest/kotlin/saschpe/log4k/LogTest.kt
@@ -20,6 +20,15 @@ class LogTest {
     }
 
     @Test
+    fun verbose_defaults() {
+        // Act
+        Log.verbose()
+
+        // Assert
+        assertTestLogger(Log.Level.Verbose, "", "", null)
+    }
+
+    @Test
     fun verbose_withLambda() {
         // Act
         Log.verbose(TEST_THROWABLE, TEST_TAG) { TEST_MESSAGE }
@@ -35,6 +44,15 @@ class LogTest {
 
         // Assert
         assertTestLogger(Log.Level.Info)
+    }
+
+    @Test
+    fun info_defaults() {
+        // Act
+        Log.info()
+
+        // Assert
+        assertTestLogger(Log.Level.Info, "", "", null)
     }
 
     @Test
@@ -56,6 +74,15 @@ class LogTest {
     }
 
     @Test
+    fun debug_defaults() {
+        // Act
+        Log.debug()
+
+        // Assert
+        assertTestLogger(Log.Level.Debug, "", "", null)
+    }
+
+    @Test
     fun debug_withLambda() {
         // Act
         Log.debug(TEST_THROWABLE, TEST_TAG) { TEST_MESSAGE }
@@ -71,6 +98,15 @@ class LogTest {
 
         // Assert
         assertTestLogger(Log.Level.Warning)
+    }
+
+    @Test
+    fun warn_defaults() {
+        // Act
+        Log.warn()
+
+        // Assert
+        assertTestLogger(Log.Level.Warning, "", "", null)
     }
 
     @Test
@@ -92,6 +128,15 @@ class LogTest {
     }
 
     @Test
+    fun error_defaults() {
+        // Act
+        Log.error()
+
+        // Assert
+        assertTestLogger(Log.Level.Error, "", "", null)
+    }
+
+    @Test
     fun error_withLambda() {
         // Act
         Log.error(TEST_THROWABLE, TEST_TAG) { TEST_MESSAGE }
@@ -107,6 +152,15 @@ class LogTest {
 
         // Assert
         assertTestLogger(Log.Level.Assert)
+    }
+
+    @Test
+    fun assert_defaults() {
+        // Act
+        Log.assert()
+
+        // Assert
+        assertTestLogger(Log.Level.Assert, "", "", null)
     }
 
     @Test


### PR DESCRIPTION
Useful in case you only want to log the class and function but have no specific message, e.g.:

```kotlin
class Foo {
    fun bar() {
        Log.debug()
    }
}
```

Will output only