### PR TITLE
Prevent NSLog from crashing if log message contains "%@" sequence

### DIFF
--- a/log4k/src/appleMain/kotlin/saschpe/log4k/ConsoleLogger.kt
+++ b/log4k/src/appleMain/kotlin/saschpe/log4k/ConsoleLogger.kt
@@ -9,7 +9,9 @@ actual class ConsoleLogger : Logger() {
     private val dateFormatter = NSDateFormatter().apply { dateFormat = "MM-dd HH:mm:ss.SSS" }
 
     actual override fun print(level: Log.Level, tag: String, message: String?, throwable: Throwable?) =
-        NSLog("${getCurrentTime()} ${levelMap[level]} ${tag.ifEmpty { getTraceTag() }}: $message")
+        NSLog("${getCurrentTime()} ${levelMap[level]} ${tag.ifEmpty { getTraceTag() }}: %s",
+            message ?: ""
+        )
 
     private fun getCurrentTime() = dateFormatter.stringFromDate(NSDate())
 


### PR DESCRIPTION
The first parameter of NSLog() is the format string where %@ is interpreted as an object argument and expected in the second, vararg, parameter of NSLog().