### PR TITLE
Update Gradle Wrapper to version 8.12.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

This pull request updates the Gradle Wrapper to version 8.12.1. Key changes include:

- Upgrading the Gradle distribution to 8.12.1.
- Updating wrapper files with added SPDX license identifiers for compliance.
- Adjusting path references and shell commands for consistency.

These updates enhance compatibility and align with the latest Gradle improvements. For more details, refer to the [Gradle 8.12.1 release notes](https://docs.gradle.org/8.12.1/release-notes.html).