### PR TITLE
Update dependencies for kotlin-wrappers and androidx-activity-compose

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mockk = "1.13.17"
 slf4j = "2.0.17"
 
 [libraries]
-androidx-activity-compose = "androidx.activity:activity-compose:1.9.2"
+androidx-activity-compose = "androidx.activity:activity-compose:1.10.1"
 kotlin-wrappers = "org.jetbrains.kotlin-wrappers:kotlin-node:22.10.2-pre.860"
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
 kotlinx-io = "org.jetbrains.kotlinx:kotlinx-io-core:0.7.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ slf4j = "2.0.17"
 
 [libraries]
 androidx-activity-compose = "androidx.activity:activity-compose:1.10.1"
-kotlin-wrappers = "org.jetbrains.kotlin-wrappers:kotlin-node:22.10.2-pre.860"
+kotlin-wrappers = "org.jetbrains.kotlin-wrappers:kotlin-node:2025.3.15-22.13.10"
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
 kotlinx-io = "org.jetbrains.kotlinx:kotlinx-io-core:0.7.0"
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
### Description

This pull request updates the following dependencies:
- **Kotlin Wrappers**: Updated to version `2025.3.15-22.13.10` for compatibility with recent library changes. See the release notes [here](https://github.com/JetBrains/kotlin-wrappers/releases/tag/2025.3.15).
- **AndroidX Activity Compose**: Updated to version `1.10.1` to align with the latest stable release and leverage new improvements.

These changes ensure the codebase remains up-to-date with the latest dependency enhancements.